### PR TITLE
Small patch for German itunes match

### DIFF
--- a/iTunesMatchHelper/iTunesLibrary.m
+++ b/iTunesMatchHelper/iTunesLibrary.m
@@ -31,7 +31,16 @@
 }
 
 + (NSUInteger)fileTrackId:(iTunesFileTrack *)track {
-    if (!([[track kind] isEqualToString:@"Matched AAC audio file"])) {
+	// Add the string of different languages here
+    if (
+		// Your language here
+		//!([[track kind] isEqualToString:@"String for AAC-file"]) &&
+
+		// German
+		!([[track kind] isEqualToString:@"Passende AAC-Audiodatei"]) &&
+
+		// English
+		!([[track kind] isEqualToString:@"Matched AAC audio file"])) {
         return 0;
     }
     


### PR DESCRIPTION
The german version of itunes match uses different strings, even when set to english. Small patch for that , including a template for other languages to add their "matching aac-file"-string in the future.
